### PR TITLE
fix: fix content URL and title

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta 
     http-equiv="refresh"
-    content="0; URL='https://weilocus.github.io/twitter/login'" />
-  <title>Twitter 404 indirect</title>
+    content="0; URL='https://weilocus.github.io/twitter/'" />
+  <title>Twitter 404 re-direct</title>
 </head>
 <body>
   


### PR DESCRIPTION
深感抱歉的我馬上修正。
我本來以為可以直接導向 https://weilocus.github.io/twitter/login，
不確定重新整理失敗的原因，但應該是要跟 github page的網址一樣！
還有打錯字的re-direct 😢